### PR TITLE
Add before-upload action hook

### DIFF
--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -27,6 +27,8 @@ export default Ember.Component.extend({
 
   'when-queued': null,
 
+  'before-upload': null,
+
   /**
     A cascading list of runtimes to fallback on to
     for uploading files with.

--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -41,7 +41,7 @@ export default Ember.ArrayProxy.extend({
 
     uploader.bind('FilesAdded',     bind(this, 'filesAdded'));
     uploader.bind('FilesRemoved',   bind(this, 'filesRemoved'));
-    uploader.bind('BeforeUpload',   bind(this, 'progressDidChange'));
+    uploader.bind('BeforeUpload',   bind(this, 'beforeUpload'));
     uploader.bind('UploadProgress', bind(this, 'progressDidChange'));
     uploader.bind('FileUploaded',   bind(this, 'fileUploaded'));
     uploader.bind('UploadComplete', bind(this, 'uploadComplete'));
@@ -109,6 +109,16 @@ export default Ember.ArrayProxy.extend({
         this.removeObject(file);
       }
     }
+  },
+
+  beforeUpload: function (uploader, file) {
+    get(this, 'target').sendAction('before-upload', file, {
+      name: get(this, 'name'),
+      uploader: uploader,
+      queue: this
+    });
+
+    this.progressDidChange(uploader, file);
   },
 
   progressDidChange: function (uploader, file) {

--- a/tests/unit/components/pl-uploader-test.js
+++ b/tests/unit/components/pl-uploader-test.js
@@ -109,6 +109,37 @@ test('sends an event when the file is queued', function (assert) {
   }]);
 });
 
+test('sends event before the file is uploaded', function (assert) {
+  assert.expect(5);
+  var target = {
+    beforeUpload: function (file, env) {
+      assert.equal(get(file, 'id'), 'test');
+      assert.equal(get(file, 'name'), 'test-filename.jpg');
+      assert.equal(get(file, 'size'), 2000);
+      assert.equal(env.name, 'test-component');
+      assert.equal(env.uploader, uploader);
+    }
+  };
+
+  var component = this.subject({
+    name: 'test-component',
+    "before-upload": 'beforeUpload',
+    uploadQueueManager: UploadQueueManager.create()
+  });
+
+  this.render();
+  set(component, 'targetObject', target);
+
+  var uploader = get(component, 'queue.queues.firstObject');
+  var fileAttributes = {
+    id: 'test',
+    name: 'test-filename.jpg',
+    size: 2000
+  };
+
+  uploader.BeforeUpload(uploader, fileAttributes);
+});
+
 test('resolves file.upload when the file upload succeeds', function (assert) {
   var done = assert.async();
   assert.expect(4);


### PR DESCRIPTION
Background is in #8. This works for me in my experiments.

One thing to note was that file.upload needs to be called for BeforeUpload event to get triggered. Like so:

```javascript
export default Ember.Route.extend({
  actions: {
    uploadImage: function (file, fileUploaderEnv) {
      let controller = this.controller;
      if (controller.get('events') == null) {
        controller.set('events', Ember.A([]));
      }

      let filename = file.get('name');
      file.read().then(function (url) {
        controller.get('events').pushObject({
          filename: filename,
          preview: url
        });
      });

      file.upload().then(function (response) {
        // this must be called otherwise BeforeUpload is never triggered
      });

      // file.destroy();
    },
    beforeUpload: function (file, fileUploaderEnv) {
      // reset fileUploaderEnv.uploader.settings.url here
    }
  }
});
```

I don't a fully working example yet, but think this should work.