### PR TITLE
Update API to allow for different upload parameters per file being uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # ember-plupload Changelog
 
-## 0.5.0 (May 9, 2015)
+## 0.6.0 (May 12, 2015)
+* #9 [BREAKING CHANGE] The `contentType` property now refers to the actual content type of the file to send. Use the `multipart` setting to determine whether the file will be sent in multiple parts using form data, or whether it's sent as a binary blob
+
+## 0.5.1 (May 9, 2015)
 * #9 [BREAKING CHANGE] `pl-uploader` components no longer accept the following attributes: `action`, `headers`, `accept`, `send-file-as`, `multipart-params`, `max-retries`, `chunk-size`, and `file-key`. These properties must now be sent via the `upload` method on files passed to the `when-queued` action.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# ember-plupload Changelog
+
+## 0.5.0 (May 9, 2015)
+* #9 [BREAKING CHANGE] `pl-uploader` components no longer accept the following attributes: `action`, `headers`, `accept`, `send-file-as`, `multipart-params`, `max-retries`, `chunk-size`, and `file-key`. These properties must now be sent via the `upload` method on files passed to the `when-queued` action.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `{{pl-uploader}}` component exposes a variety of parameters for configuring 
 
 This configuration is for the uploader instance as a whole. Most of the configuration deals directly with the feel of the uploader. When the queued event is triggered, you will be given a file object that allows you to configure where the file is being uploaded:
 
-| Attribute           | Definition
+| Property            | Definition
 |---------------------|------------------|
 | `url`               | the URL to send the upload request to
 | `headers`           | the headers to use when uploading the file. it defaults to using the `accept` attribute

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This configuration is for the uploader instance as a whole. Most of the configur
 | `url`               | the URL to send the upload request to
 | `headers`           | the headers to use when uploading the file. it defaults to using the `accept` attribute
 | `accepts`           | a string or array of accepted content types that the server can respond with. defaults to `['application/json', 'text/javascript']`
-| `contentType`       | how the file should be sent. defaults to `multipart/form-data`; `binary` is the other option
+| `contentType`       | correlates to the Content-Type header of the headers. defaults to the type of the file
 | `data`              | multipart params to send along with the upload
+| `multipart`         | whether the file should be sent using using a multipart form object or as a binary stream.
 | `maxRetries`        | the maximum number of times to retry uploading the file
 | `chunkSize`         | the chunk size to split the file into when sending to the server
 | `fileKey`          | the name of the parameter to send the file as. defaults to `file`

--- a/README.md
+++ b/README.md
@@ -12,21 +12,28 @@ The `{{pl-uploader}}` component exposes a variety of parameters for configuring 
 | Attribute           | Definition
 |---------------------|------------------|
 | `when-queued`       | the name of the action on a route to be called when a file is queued to be uploaded
-| `action`            | the URL to send the upload request to
 | `for`               | the ID of the browse button
 | `max-file-size`     | the maximum size of file uploads
 | `no-duplicates`     | disallow duplicate files (determined by matching the file's name and size)
 | `extensions`        | a space-separated list of allowed file extensions
-| `headers`           | the headers to use when uploading the file. it defaults to using the `accept` attribute
-| `accept`            | a space-separated list of accepted content types that the server can respond with. defaults to `application/json text/javascript`
-| `send-file-as`      | how the file should be sent. defaults to `multipart/form-data`; `binary` is the other option
-| `multipart-params`  | multipart params to send along with the upload
-| `max-retries`       | the maximum number of times to retry uploading the file
-| `chunk-size`        | the chunk size to split the file into when sending to the server
 | `multiple`          | whether multiple files can be selected
 | `unique-names`      | when set to `true`, this will rename files sent to the server and send the original name as a parameter named `name`
 | `runtimes`          | a space-separated list of runtimes for plupload to attempt to use (in order of importance)
-| `file-key`          | the name of the parameter to send the file as. defaults to `file`
+
+This configuration is for the uploader instance as a whole. Most of the configuration deals directly with the feel of the uploader. When the queued event is triggered, you will be given a file object that allows you to configure where the file is being uploaded:
+
+| Attribute           | Definition
+|---------------------|------------------|
+| `url`               | the URL to send the upload request to
+| `headers`           | the headers to use when uploading the file. it defaults to using the `accept` attribute
+| `accepts`           | a string or array of accepted content types that the server can respond with. defaults to `['application/json', 'text/javascript']`
+| `contentType`       | how the file should be sent. defaults to `multipart/form-data`; `binary` is the other option
+| `data`              | multipart params to send along with the upload
+| `maxRetries`        | the maximum number of times to retry uploading the file
+| `chunkSize`         | the chunk size to split the file into when sending to the server
+| `fileKey`          | the name of the parameter to send the file as. defaults to `file`
+
+The function signature of `upload` is `upload(url, [settings])`, or `upload(settings)`.
 
 For more in-depth documentation on the configuration options, see the [Plupload documentation](http://plupload.com/docs/Options).
 
@@ -37,7 +44,7 @@ The cleanest approach to configure uploaders is to create a component that encap
 For example, creating an image uploader that uploads images to your API server would look like:
 
 ```handlebars
-{{#pl-uploader extensions="jpg jpeg png gif" action="/api/images/upload" for="upload-image" when-queued="uploadImage" as |queue features|}}
+{{#pl-uploader for="upload-image" extensions="jpg jpeg png gif" when-queued="uploadImage" as |queue features|}}
   <div class="dropzone" id={{features.drag-and-drop.dropzone-id}}>
     {{#if features.drag-and-drop.drag-data}}
       {{#if features.drag-and-drop.drag-data.valid}}
@@ -89,7 +96,7 @@ export default Ember.Route.extend({
         }
       });
 
-      file.upload().then(function (response) {
+      file.upload('/api/images/upload').then(function (response) {
         set(image, 'url', response.headers.Location);
         return image.save();
       }, function () {

--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -36,26 +36,13 @@ export default Ember.Component.extend({
     @default ['html5', 'html4', 'flash', 'silverlight']
    */
   runtimes: w(['html5', 'html4', 'flash', 'silverlight']),
-  accept: w(['application/json', 'text/javascript']),
   extensions: w(),
-  headers: Ember.computed('accept', function () {
-    return {
-      Accept: get(this, 'accept').join(',')
-    };
-  }),
 
   "max-file-size": 0,
   "no-duplicates": false,
 
-  "send-file-as": "multipart/form-data",
-  "multipart-params": null,
-  "max-retries": 0,
-  "chunk-size": 0,
-
   multiple: true,
   "unique-names": false,
-
-  "file-key": "file",
 
   features: Ember.computed(function () {
     var features = {};
@@ -70,40 +57,27 @@ export default Ember.Component.extend({
   }),
 
   config: Ember.computed(function () {
-    Ember.assert(
-      "Files can only be sent as 'multipart/form-data' or 'binary'.",
-      ['multipart/form-data', 'binary'].indexOf(get(this, 'send-file-as')) !== -1);
-
     var config  = {
       browse_button: get(this, 'for'),
-      url: get(this, 'action'),
       filters: {
         max_file_size: get(this, 'max-file-size'),
         prevent_duplicates: get(this, 'no-duplicates')
       },
 
-      headers: get(this, 'headers'),
-      multipart: get(this, 'send-file-as') === 'multipart/form-data',
-      multipart_params: get(this, 'multipart-params') || {},
-      max_retries: get(this, 'max-retries'),
-      chunk_size: get(this, 'chunk-size'),
-
       multi_selection: get(this, 'multiple'),
       required_features: true,
-      unique_names: get(this, 'unique-names'),
 
       runtimes: get(this, 'runtimes').join(','),
-      file_data_name: get(this, 'file-key'),
       container: get(this, 'elementId'),
       flash_swf_url: this.BASE_URL + 'Moxie.swf',
-      silverlight_xap_url: this.BASE_URL + 'Moxie.xap'
+      silverlight_xap_url: this.BASE_URL + 'Moxie.xap',
+      unique_names: get(this, 'unique-names')
     };
 
     var filters = get(this, 'fileFilters') || {};
-    var self = this;
-    keys(filters).forEach(function (filter) {
-      if (get(self, filter)) {
-        config.filters[filter] = get(self, filter);
+    keys(filters).forEach((filter) => {
+      if (get(this, filter)) {
+        config.filters[filter] = get(this, filter);
       }
     });
 

--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -58,6 +58,7 @@ export default Ember.Component.extend({
 
   config: Ember.computed(function () {
     var config  = {
+      url: true, // Required to init plupload
       browse_button: get(this, 'for'),
       filters: {
         max_file_size: get(this, 'max-file-size'),

--- a/addon/system/file.js
+++ b/addon/system/file.js
@@ -103,7 +103,7 @@ export default Ember.Object.extend({
     } else {
       settings.url = url;
     }
-    this.config = settingsToConfig(settings || {});
+    this.settings = settingsToConfig(settings);
 
     // Start uploading the files
     later(uploader, 'start', 100);

--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -51,8 +51,11 @@ export default Ember.ArrayProxy.extend({
 
     get(this, 'queues').pushObject(uploader);
 
+    let settings = copy(uploader.settings);
+    delete settings.url;
+    set(this, 'settings', settings);
+
     uploader.init();
-    set(this, 'config', copy(uploader.config));
     return uploader;
   },
 
@@ -116,9 +119,9 @@ export default Ember.ArrayProxy.extend({
 
   configureUpload: function (uploader, file) {
     file = this.findProperty('id', file.id);
-    // Reset config for merging
-    uploader.config = copy(get(this, 'config'));
-    merge(uploader.config, file.config);
+    // Reset settings for merging
+    uploader.settings = copy(get(this, 'settings'));
+    merge(uploader.settings, file.settings);
 
     this.progressDidChange(uploader, file);
   },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,5 +14,10 @@ module.exports = {
     dependencies: {
       'ember': 'beta'
     }
+  }, {
+    name: 'canary',
+    dependencies: {
+      'ember': 'canary'
+    }
   }]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-plupload",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-plupload",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-plupload",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/helpers/mock-uploader.js
+++ b/tests/helpers/mock-uploader.js
@@ -1,8 +1,8 @@
 export default function (config) {
   var removedFiles = [];
   return {
-    config: config,
     removedFiles: removedFiles,
+    settings: config || {},
 
     total: {
       queued: 0,

--- a/tests/unit/components/pl-uploader-test.js
+++ b/tests/unit/components/pl-uploader-test.js
@@ -39,7 +39,8 @@ test('it configures the plupload Uploader correctly', function (assert) {
   var elementId = get(component, 'elementId');
 
   assert.ok(uploader.initialized);
-  assert.deepEqual(uploader.config, {
+  assert.deepEqual(uploader.settings, {
+    url: true,
     runtimes: 'html5,html4,flash,silverlight',
     browse_button: 'browse-button',
     drop_element: get(component, 'features.drag-and-drop') ? 'dropzone-for-' + elementId : null,
@@ -170,7 +171,7 @@ test('merges uploader settings with the settings provided in file.upload', funct
     assert.ok(uploader.started);
 
     uploader.BeforeUpload(uploader, file);
-    assert.deepEqual(uploader.config, {
+    assert.deepEqual(uploader.settings, {
       runtimes: 'html5,html4,flash,silverlight',
       url: 'https://my-bucket.amazonaws.com/test',
       browse_button: 'browse-button',
@@ -240,7 +241,7 @@ test('merges the url correctly if passed in as the first parameter to upload', f
     assert.ok(uploader.started);
 
     uploader.BeforeUpload(uploader, file);
-    assert.deepEqual(uploader.config, {
+    assert.deepEqual(uploader.settings, {
       runtimes: 'html5,html4,flash,silverlight',
       url: 'https://my-bucket.amazonaws.com/test',
       browse_button: 'browse-button',

--- a/tests/unit/components/pl-uploader-test.js
+++ b/tests/unit/components/pl-uploader-test.js
@@ -140,6 +140,7 @@ test('merges uploader settings with the settings provided in file.upload', funct
     uploadImage: function (file, env) {
       file.upload({
         url: 'https://my-bucket.amazonaws.com/test',
+        method: 'PUT',
         accepts: 'text/plain',
         data: {
           signature: 'test'
@@ -164,7 +165,7 @@ test('merges uploader settings with the settings provided in file.upload', funct
   set(component, 'targetObject', target);
 
   var uploader = get(component, 'queue.queues.firstObject');
-  var file = { id: 'test' };
+  var file = { id: 'test', type: 'image/gif' };
 
   uploader.FilesAdded(uploader, [file]);
   setTimeout(function () {
@@ -181,6 +182,7 @@ test('merges uploader settings with the settings provided in file.upload', funct
       silverlight_xap_url: '/assets/Moxie.xap',
       max_retries: 2,
       chunk_size: 128,
+      method: 'PUT',
       multipart: true,
       multipart_params: {
         signature: 'test'
@@ -197,7 +199,8 @@ test('merges uploader settings with the settings provided in file.upload', funct
         prevent_duplicates: true
       },
       headers: {
-        Accept: 'text/plain'
+        Accept: 'text/plain',
+        'Content-Type': 'image/gif'
       }
     });
     done();
@@ -211,6 +214,7 @@ test('merges the url correctly if passed in as the first parameter to upload', f
     uploadImage: function (file, env) {
       file.upload('https://my-bucket.amazonaws.com/test', {
         accepts: 'text/plain',
+        contentType: 'text/plain',
         data: {
           signature: 'test'
         },
@@ -234,7 +238,7 @@ test('merges the url correctly if passed in as the first parameter to upload', f
   set(component, 'targetObject', target);
 
   var uploader = get(component, 'queue.queues.firstObject');
-  var file = { id: 'test' };
+  var file = { id: 'test', type: 'image/gif' };
 
   uploader.FilesAdded(uploader, [file]);
   setTimeout(function () {
@@ -251,6 +255,7 @@ test('merges the url correctly if passed in as the first parameter to upload', f
       silverlight_xap_url: '/assets/Moxie.xap',
       max_retries: 2,
       chunk_size: 128,
+      method: 'POST',
       multipart: true,
       multipart_params: {
         signature: 'test'
@@ -267,7 +272,8 @@ test('merges the url correctly if passed in as the first parameter to upload', f
         prevent_duplicates: true
       },
       headers: {
-        Accept: 'text/plain'
+        Accept: 'text/plain',
+        'Content-Type': 'text/plain'
       }
     });
     done();

--- a/tests/unit/components/pl-uploader-test.js
+++ b/tests/unit/components/pl-uploader-test.js
@@ -27,16 +27,9 @@ test('it configures the plupload Uploader correctly', function (assert) {
   var component = this.subject({
     for: 'browse-button',
     "when-queued": 'uploadImage',
-    action: 'https://my-bucket.amazonaws.com/test',
-    accept: 'text/plain',
     extensions: 'JPG PNG GIF',
-    "multipart-params": {
-      signature: 'test'
-    },
     "max-file-size": 256,
     "no-duplicates": true,
-    "max-retries": 2,
-    "chunk-size": 128,
     uploadQueueManager: UploadQueueManager.create()
   });
 
@@ -48,20 +41,12 @@ test('it configures the plupload Uploader correctly', function (assert) {
   assert.ok(uploader.initialized);
   assert.deepEqual(uploader.config, {
     runtimes: 'html5,html4,flash,silverlight',
-    url: 'https://my-bucket.amazonaws.com/test',
     browse_button: 'browse-button',
     drop_element: get(component, 'features.drag-and-drop') ? 'dropzone-for-' + elementId : null,
     container: elementId,
     flash_swf_url: '/assets/Moxie.swf',
     silverlight_xap_url: '/assets/Moxie.xap',
-    max_retries: 2,
-    chunk_size: 128,
-    multipart: true,
-    multipart_params: {
-      signature: 'test'
-    },
     required_features: true,
-    file_data_name: 'file',
     unique_names: false,
     multi_selection: true,
     filters: {
@@ -70,9 +55,6 @@ test('it configures the plupload Uploader correctly', function (assert) {
       }],
       max_file_size: 256,
       prevent_duplicates: true
-    },
-    headers: {
-      Accept: 'text/plain'
     }
   });
 });
@@ -145,6 +127,147 @@ test('resolves file.upload when the file upload succeeds', function (assert) {
       status: 200,
       responseHeaders: "Location: https://my-server.com/remote-url.jpg\nContent-Type: application/json; charset=utf-8",
       response: '{ "name": "test-filename.jpg" }'
+    });
+    done();
+  }, 100);
+});
+
+test('merges uploader settings with the settings provided in file.upload', function (assert) {
+  var done = assert.async();
+  assert.expect(2);
+  var target = {
+    uploadImage: function (file, env) {
+      file.upload({
+        url: 'https://my-bucket.amazonaws.com/test',
+        accepts: 'text/plain',
+        data: {
+          signature: 'test'
+        },
+        maxRetries: 2,
+        chunkSize: 128
+      });
+    }
+  };
+
+  var component = this.subject({
+    for: 'browse-button',
+    "when-queued": 'uploadImage',
+    extensions: 'JPG PNG GIF',
+    "max-file-size": 256,
+    "no-duplicates": true,
+    uploadQueueManager: UploadQueueManager.create()
+  });
+  var elementId = get(component, 'elementId');
+
+  this.render();
+  set(component, 'targetObject', target);
+
+  var uploader = get(component, 'queue.queues.firstObject');
+  var file = { id: 'test' };
+
+  uploader.FilesAdded(uploader, [file]);
+  setTimeout(function () {
+    assert.ok(uploader.started);
+
+    uploader.BeforeUpload(uploader, file);
+    assert.deepEqual(uploader.config, {
+      runtimes: 'html5,html4,flash,silverlight',
+      url: 'https://my-bucket.amazonaws.com/test',
+      browse_button: 'browse-button',
+      drop_element: get(component, 'features.drag-and-drop') ? 'dropzone-for-' + elementId : null,
+      container: elementId,
+      flash_swf_url: '/assets/Moxie.swf',
+      silverlight_xap_url: '/assets/Moxie.xap',
+      max_retries: 2,
+      chunk_size: 128,
+      multipart: true,
+      multipart_params: {
+        signature: 'test'
+      },
+      required_features: true,
+      file_data_name: 'file',
+      unique_names: false,
+      multi_selection: true,
+      filters: {
+        mime_types: [{
+          extensions: 'jpg,png,gif'
+        }],
+        max_file_size: 256,
+        prevent_duplicates: true
+      },
+      headers: {
+        Accept: 'text/plain'
+      }
+    });
+    done();
+  }, 100);
+});
+
+test('merges the url correctly if passed in as the first parameter to upload', function (assert) {
+  var done = assert.async();
+  assert.expect(2);
+  var target = {
+    uploadImage: function (file, env) {
+      file.upload('https://my-bucket.amazonaws.com/test', {
+        accepts: 'text/plain',
+        data: {
+          signature: 'test'
+        },
+        maxRetries: 2,
+        chunkSize: 128
+      });
+    }
+  };
+
+  var component = this.subject({
+    for: 'browse-button',
+    "when-queued": 'uploadImage',
+    extensions: 'JPG PNG GIF',
+    "max-file-size": 256,
+    "no-duplicates": true,
+    uploadQueueManager: UploadQueueManager.create()
+  });
+  var elementId = get(component, 'elementId');
+
+  this.render();
+  set(component, 'targetObject', target);
+
+  var uploader = get(component, 'queue.queues.firstObject');
+  var file = { id: 'test' };
+
+  uploader.FilesAdded(uploader, [file]);
+  setTimeout(function () {
+    assert.ok(uploader.started);
+
+    uploader.BeforeUpload(uploader, file);
+    assert.deepEqual(uploader.config, {
+      runtimes: 'html5,html4,flash,silverlight',
+      url: 'https://my-bucket.amazonaws.com/test',
+      browse_button: 'browse-button',
+      drop_element: get(component, 'features.drag-and-drop') ? 'dropzone-for-' + elementId : null,
+      container: elementId,
+      flash_swf_url: '/assets/Moxie.swf',
+      silverlight_xap_url: '/assets/Moxie.xap',
+      max_retries: 2,
+      chunk_size: 128,
+      multipart: true,
+      multipart_params: {
+        signature: 'test'
+      },
+      required_features: true,
+      file_data_name: 'file',
+      unique_names: false,
+      multi_selection: true,
+      filters: {
+        mime_types: [{
+          extensions: 'jpg,png,gif'
+        }],
+        max_file_size: 256,
+        prevent_duplicates: true
+      },
+      headers: {
+        Accept: 'text/plain'
+      }
     });
     done();
   }, 100);


### PR DESCRIPTION
This is a significant API change (with the deprecations marked in `CHANGELOG.md`).

The current API wasn't flexible to handle different parameters per file being uploaded. This pull request fixes that by passing in the configuration to be merged into the `upload` method of the file. Note that this approach only works because simultaneous uploads aren't currently possible with the current version of plupload.