### PR TITLE
Bugfix/file upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log
 testem.log
 *~
+.*


### PR DESCRIPTION
in file.js you have : 
```    if (settings == null) {
      settings = url;
    } else {
      settings.url = url;
    }```

If both url and settings are provided, the URL given is well moved to settings.url, but 
the settings == null part does not seem to work and will die on : 

`TypeError: Cannot assign to read only property 'method' of https://my-bucket.amazonaws.com/test`

as shown by this unit test.