### PR TITLE
Don't reject when server responds with 201 created

### DIFF
--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -188,7 +188,8 @@ export default Ember.ArrayProxy.extend({
     // NOTE: Plupload calls UploadProgress upon triggering FileUploaded,
     //       so we don't need to trigger a progress event
     if (results.status === 204 ||
-        results.status === 200) {
+        results.status === 200 ||
+        results.status === 201) {
       file._deferred.resolve(results);
     } else {
       file._deferred.reject(results);


### PR DESCRIPTION
Was confused for a bit why all my uploads were being rejected even though the server was responding with a success code. Seems like `201` is a pretty normal response for a uploaded file.