### PR TITLE
Check for lower case content-type header

### DIFF
--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -159,7 +159,7 @@ export default Ember.ArrayProxy.extend({
       return headers;
     }, {});
 
-    var contentType = (headers['Content-Type'] || '').split(';');
+    var contentType = (headers['Content-Type'] || headers['content-type'] || '').split(';');
     // Parse body according to the Content-Type received by the server
     if (contentType.indexOf('text/html') !== -1) {
       body = Ember.$.parseHTML(body);


### PR DESCRIPTION
Headers are case insenstive. IIS seems to return `content-type` and not `Content-Type`. This I guess could still break if someone did `CONTENT-TYPE` or `ConTeNT-TYPE` but lets not get silly.