### PR TITLE
Update Blueprint for newest ember cli

### DIFF
--- a/blueprints/ember-plupload/index.js
+++ b/blueprints/ember-plupload/index.js
@@ -3,8 +3,8 @@ module.exports = {
 
   afterInstall: function() {
     var self = this;
-    return this.addBowerPackageToProject('plupload#2.1.3').then(function () {
-      return self.addBowerPackageToProject('dinosheets#0.0.1');
+    return this.addBowerPackageToProject('plupload', 'v2.1.8').then(function () {
+      return self.addBowerPackageToProject('dinosheets', '0.0.1');
     });
   }
 };


### PR DESCRIPTION
Update the ember-plupload blueprint `addBowerPackageToProject` to accept 2 arguments, package name and version number.

Change due to this update in ember-cli: https://github.com/ember-cli/ember-cli/pull/4643

Fixes #34 