### PR TITLE
Refresh the uploader on queue change

### DIFF
--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -223,7 +223,16 @@ export default Ember.Component.extend({
       this.deactivateDropzone();
     }
     this._queued = get(this, 'queue.length');
+    Ember.run.scheduleOnce('afterRender', this, 'refreshQueue');
   }),
+
+  refreshQueue() {
+    var queue = this.get('queue');
+
+    if (queue) {
+      queue.refresh();
+    }
+  },
 
   setDragDataValidity: Ember.observer('dragData', Ember.on('init', function () {
     if (!isDragAndDropSupported(get(this, 'runtimes'))) { return; }


### PR DESCRIPTION
This solves the issue where the browse button moves
around, like if it's at the bottom of the page, and you display
the added files, and ass you add more files the button moves down.
Also solves the problem where you remove all files.

This keeps the browse button and any UI in the dropzone usable.

@tim-evans this is the issue we were talking about in slack.