### PR TITLE
allow drag and drop to keep working when no duplicates is true

### DIFF
--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -218,7 +218,7 @@ export default Ember.Component.extend({
   _invalidateDragData: Ember.observer('queue.length', function () {
     // Looks like someone dropped a file
     const filesAdded = get(this, 'queue.length') > this._queued;
-    const filesDropped = get(this, 'queue.length') === 0 && this._queued === 0;
+    const filesDropped = get(this, 'queue.length') === this._queued;
     if ((filesAdded || filesDropped) && get(this, 'dragData')) {
       this.deactivateDropzone();
     }


### PR DESCRIPTION
The problem here is when `no-duplicates` is set to true, and a user tries to drag-and-drop the same file, `deactivateDropzone` is never called, and it freezes the elements on plupload.

When happens in the `_invalidateDragData` method is that `filesDropped` is never true, so the dropzone was never deactivated, even after the user `dropped` the file.

For example, on line 3 of `application.hbs` set `no-duplicates=true` and on line 19 change `<a id="upload-image">Add an Image.</a>` to `<button id="upload-image">Add an Image.</button>`. Also, in `application.js` comment out line 19.

now click add an image, notice how the button is pressable. Add an image. Now click add an image again. Add the same file. The file is correctly rejected. Now click add an image again, notice how the button still works. Now, try to drag and drop that same file. The file is correctly rejected. However, the button no longer is pressable.

Furthermore, when having the ember-plupload component for an entire form, the form freezes.

This change fixes that problem.